### PR TITLE
update metadata

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -1,6 +1,6 @@
 {
     "key": "parameter_python",
-    "name": "Parameter Python bindings",
+    "name": "Parameter Python Bindings",
     "authors": [
         "David Abrahams",
         "Daniel Wallin"


### PR DESCRIPTION
How the name field is displayed on boost.org website: "Parameter Python Bindings".