### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,23 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/parameter_python
+    : common-requirements
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/parameter//boost_parameter
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/python//boost_python
+        <include>include
+    ;
+
+explicit
+    [ alias boost_parameter_python ]
+    [ alias all : boost_parameter_python test ]
+    ;
+
+call-if : boost-library parameter_python
+    ;

--- a/build.jam
+++ b/build.jam
@@ -7,10 +7,10 @@ import project ;
 
 project /boost/parameter_python
     : common-requirements
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/parameter//boost_parameter
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/python//boost_python
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/parameter//boost_parameter
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/python//boost_python
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/parameter_python

--- a/build.jam
+++ b/build.jam
@@ -5,19 +5,22 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/mpl//boost_mpl
+    /boost/parameter//boost_parameter
+    /boost/preprocessor//boost_preprocessor
+    /boost/python//boost_python ;
+
 project /boost/parameter_python
     : common-requirements
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/parameter//boost_parameter
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/python//boost_python
         <include>include
     ;
 
 explicit
-    [ alias boost_parameter_python ]
+    [ alias boost_parameter_python : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_parameter_python test ]
     ;
 
 call-if : boost-library parameter_python
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/parameter_python
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -12,12 +12,11 @@ constant boost_dependencies :
     /boost/python//boost_python ;
 
 project /boost/parameter_python
-    : common-requirements
-        <include>include
     ;
 
 explicit
-    [ alias boost_parameter_python : : : : <library>$(boost_dependencies) ]
+    [ alias boost_parameter_python : : :
+        : <include>include <library>$(boost_dependencies) ]
     [ alias all : boost_parameter_python test ]
     ;
 


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.